### PR TITLE
Ignore *.swp files by default

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -159,6 +159,7 @@ silent=$unisonsilent
 ignore = Path .git/*
 ignore = Path .idea/*
 ignore = Name *___jb_tmp___*
+ignore = Name {.*,*}.sw[pon]
 
 # Additional user configuration
 $SYNC_EXTRA_UNISON_PROFILE_OPTS


### PR DESCRIPTION
Having set `SYNC_PREFER=newer` a lot of *.swp files tend to appear on the host volume after you edit a file inside the container. Let's exclude them by default.

Referring Stack question and answer: https://superuser.com/questions/569176/how-to-make-unison-ignore-all-files-with-swp-extension