### PR TITLE
Default SYNC_PREFER=newer

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -40,7 +40,7 @@ fi
 : ${SYNC_DESTINATION:="/destination"}
 
 # The preferred approach to deal with conflicts
-: ${SYNC_PREFER:=$SYNC_SOURCE}
+: ${SYNC_PREFER:="newer"}
 
 # If set, there will be more verbose log output from various commands that are
 # run by this script.


### PR DESCRIPTION
It seems confusing for some folks (and me) that after the initial sync the ongoing sync is only unidirectional (container to host only). Let's make it bidirectional by default. Refs #2