### PR TITLE
avoid error user/group already exists

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -22,8 +22,17 @@ log_error_exit() {
 if [ "$UNISON_USER" != "root" ]; then
   log_heading "Setting up non-root user ${UNISON_USER}."
   HOME="/home/${UNISON_USER}"
-  addgroup -g $UNISON_GID -S $UNISON_GROUP
-  adduser -u $UNISON_UID -D -S -G $UNISON_GROUP $UNISON_USER
+
+  if [ ! $(getent group ${UNISON_GROUP}) ]; then
+    log_info "Creating group ${UNISON_GROUP}"
+    addgroup -g $UNISON_GID -S $UNISON_GROUP
+  fi
+
+  if [ ! $(getent passwd ${UNISON_USER}) ]; then
+    log_info "Creating user ${UNISON_USER}"
+    adduser -u $UNISON_UID -D -S -G $UNISON_GROUP $UNISON_USER
+  fi
+
   mkdir -p ${HOME}/.unison
   chown -R ${UNISON_USER}:${UNISON_GROUP} ${HOME}
 fi


### PR DESCRIPTION
Hi! First of all thanks a lot for your work!

Working with this image I found an error, when you use the env variables: UNISON_USER, UNISON_GROUP, UNISON_GID, UNISON_UID. The container fails when you run docker-compose up after the first time.

The problem is that the user/group are created inside a script, that is executed every time you turn on the container. So if the user/group already exists (they are created the first time you build the container) it will fail: addgroup: group 'NAME' in use, and the same for the user.

So you've the option of always use --build when turning on the container.

The ideal solution should be delete the user/group and create them again, because you could've only changed the GID/UID. But as you're using alpine groupdel/userdel are not available and I don't want to install anything in your image!

So in resume, I've just added a check that will only create the user/group when they doesn't exists.

Regards!

(If you want to reproduce it, just set the env variables and run docker-compose up SERVICE_NAME twice, the second time it should fail)